### PR TITLE
feat: cache control

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,17 +59,18 @@ services:
   nginx:
     image: nginx:1.15-alpine
     ports:
-       - "80:80"
-       - "443:443"
+      - "80:80"
+      - "443:443"
     command: "/bin/sh -c 'while :; do sleep 10s & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
     volumes:
-       - ./local/nginx/conf.d:/etc/nginx/conf.d
-       - ./local/certbot/conf:/etc/letsencrypt
-       - ./local/certbot/www:/var/www/certbot
+      - ./local/nginx/conf.d:/etc/nginx/conf.d
+      - ./local/certbot/conf:/etc/letsencrypt
+      - ./local/certbot/www:/var/www/certbot
+      - "${CONTENT_SERVER_STORAGE}:/var/www/content/"
     depends_on:
-       - lambdas
-       - content-server
-       - comms-server
+      - lambdas
+      - content-server
+      - comms-server
     logging:
       options:
         max-size: "100M"
@@ -84,4 +85,4 @@ services:
     logging:
       options:
         max-size: "100M"
-        max-file: "10"      
+        max-file: "10"

--- a/local/nginx/conf.d/katalyst-https.conf.template
+++ b/local/nginx/conf.d/katalyst-https.conf.template
@@ -40,6 +40,10 @@ server {
         try_files /$1 /404.html;
         add_header Cache-Control "public, max-age=31536000, immutable";
         add_header Content-Type application/wasm;
+        add_header Access-Control-Allow-Origin "*";
+        add_header Access-Control-Expose-Headers "*";
+        add_header Access-Control-Allow-Methods "GET,HEAD,OPTIONS";
+        add_header Access-Control-Request-Headers "*";
     }
 
     location ~ ^/lambdas/contentv2/contents/(.*)$ {
@@ -47,6 +51,10 @@ server {
         try_files /$1 /404.html;
         add_header Cache-Control "public, max-age=31536000, immutable";
         add_header Content-Type application/wasm;
+        add_header Access-Control-Allow-Origin "*";
+        add_header Access-Control-Expose-Headers "*";
+        add_header Access-Control-Allow-Methods "GET,HEAD,OPTIONS";
+        add_header Access-Control-Request-Headers "*";
     }
 
     location ~ ^/content(.*)$ {

--- a/local/nginx/conf.d/katalyst-https.conf.template
+++ b/local/nginx/conf.d/katalyst-https.conf.template
@@ -43,6 +43,7 @@ server {
         add_header Access-Control-Allow-Origin "*";
         add_header Access-Control-Expose-Headers "ETag";
         add_header Access-Control-Allow-Methods "GET,HEAD,OPTIONS";
+	add_header ETag $1;
         add_header Access-Control-Allow-Headers "Accept, Accept-Encoding, Access-Control-Allow-Credentials, Access-Control-Allow-Headers, Access-Control-Allow-Methods, Access-Control-Allow-Origin, Access-Control-Max-Age, Age, Allow,Authentication-Info, Authorization, CONNECT, Cache-Control, Connection, Content-Base, Content-Length, Content-Location, Content-MD5, Content-Type, Content-Version, Cookie, DELETE, Destination, Expires, ETag, From, GET, HEAD, Host, Keep-Alive, Location, MIME-Version, OPTION, OPTIONS, Optional, Origin, POST, PUT, Protocol, Proxy-Authenticate, Proxy-Authentication-Info, Proxy-Authorization, Proxy-Features, Public, Referer, Refresh, Resolver-Location, Sec-Websocket-Extensions, Sec-Websocket-Key, Sec-Websocket-Origin, Sec-Websocket-Protocol, Sec-Websocket-Version, Security-Scheme, Server, Set-Cookie, et-Cookie2, SetProfile, Status, Timeout, Title, URI, User-Agent, Version, WWW-Authenticate, X-Content-Duration, X-Content-Security-Policy, X-Content-Type-Options, X-CustomHeader, X-DNSPrefetch-Control, X-Forwarded-For, X-Forwarded-Port, X-Forwarded-Proto, X-Frame-Options, X-Modified, X-OTHER, X-PING, X-Requested-With";
     }
 
@@ -54,6 +55,7 @@ server {
         add_header Access-Control-Allow-Origin "*";
         add_header Access-Control-Expose-Headers "ETag";
         add_header Access-Control-Allow-Methods "GET,HEAD,OPTIONS";
+	add_header ETag $1;
         add_header Access-Control-Allow-Headers "Accept, Accept-Encoding, Access-Control-Allow-Credentials, Access-Control-Allow-Headers, Access-Control-Allow-Methods, Access-Control-Allow-Origin, Access-Control-Max-Age, Age, Allow,Authentication-Info, Authorization, CONNECT, Cache-Control, Connection, Content-Base, Content-Length, Content-Location, Content-MD5, Content-Type, Content-Version, Cookie, DELETE, Destination, Expires, ETag, From, GET, HEAD, Host, Keep-Alive, Location, MIME-Version, OPTION, OPTIONS, Optional, Origin, POST, PUT, Protocol, Proxy-Authenticate, Proxy-Authentication-Info, Proxy-Authorization, Proxy-Features, Public, Referer, Refresh, Resolver-Location, Sec-Websocket-Extensions, Sec-Websocket-Key, Sec-Websocket-Origin, Sec-Websocket-Protocol, Sec-Websocket-Version, Security-Scheme, Server, Set-Cookie, et-Cookie2, SetProfile, Status, Timeout, Title, URI, User-Agent, Version, WWW-Authenticate, X-Content-Duration, X-Content-Security-Policy, X-Content-Type-Options, X-CustomHeader, X-DNSPrefetch-Control, X-Forwarded-For, X-Forwarded-Port, X-Forwarded-Proto, X-Frame-Options, X-Modified, X-OTHER, X-PING, X-Requested-With";
     }
 

--- a/local/nginx/conf.d/katalyst-https.conf.template
+++ b/local/nginx/conf.d/katalyst-https.conf.template
@@ -35,6 +35,19 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/$katalyst_host/privkey.pem;
     client_max_body_size 256M;
 
+    location ~ ^/content/contents/(.*)$ {
+        root /var/www/content/contents;
+        try_files /$1 /404.html;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        add_header Content-Type application/wasm;
+    }
+
+    location ~ ^/lambdas/contentv2/contents/(.*)$ {
+        root /var/www/content/contents;
+        try_files /$1 /404.html;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        add_header Content-Type application/wasm;
+    }
 
     location ~ ^/content(.*)$ {
         proxy_pass http://content-server$1$is_args$args;

--- a/local/nginx/conf.d/katalyst-https.conf.template
+++ b/local/nginx/conf.d/katalyst-https.conf.template
@@ -41,9 +41,9 @@ server {
         add_header Cache-Control "public, max-age=31536000, immutable";
         add_header Content-Type application/wasm;
         add_header Access-Control-Allow-Origin "*";
-        add_header Access-Control-Expose-Headers "*";
+        add_header Access-Control-Expose-Headers "ETag";
         add_header Access-Control-Allow-Methods "GET,HEAD,OPTIONS";
-        add_header Access-Control-Request-Headers "*";
+        add_header Access-Control-Allow-Headers "Accept, Accept-Encoding, Access-Control-Allow-Credentials, Access-Control-Allow-Headers, Access-Control-Allow-Methods, Access-Control-Allow-Origin, Access-Control-Max-Age, Age, Allow,Authentication-Info, Authorization, CONNECT, Cache-Control, Connection, Content-Base, Content-Length, Content-Location, Content-MD5, Content-Type, Content-Version, Cookie, DELETE, Destination, Expires, ETag, From, GET, HEAD, Host, Keep-Alive, Location, MIME-Version, OPTION, OPTIONS, Optional, Origin, POST, PUT, Protocol, Proxy-Authenticate, Proxy-Authentication-Info, Proxy-Authorization, Proxy-Features, Public, Referer, Refresh, Resolver-Location, Sec-Websocket-Extensions, Sec-Websocket-Key, Sec-Websocket-Origin, Sec-Websocket-Protocol, Sec-Websocket-Version, Security-Scheme, Server, Set-Cookie, et-Cookie2, SetProfile, Status, Timeout, Title, URI, User-Agent, Version, WWW-Authenticate, X-Content-Duration, X-Content-Security-Policy, X-Content-Type-Options, X-CustomHeader, X-DNSPrefetch-Control, X-Forwarded-For, X-Forwarded-Port, X-Forwarded-Proto, X-Frame-Options, X-Modified, X-OTHER, X-PING, X-Requested-With";
     }
 
     location ~ ^/lambdas/contentv2/contents/(.*)$ {
@@ -52,9 +52,9 @@ server {
         add_header Cache-Control "public, max-age=31536000, immutable";
         add_header Content-Type application/wasm;
         add_header Access-Control-Allow-Origin "*";
-        add_header Access-Control-Expose-Headers "*";
+        add_header Access-Control-Expose-Headers "ETag";
         add_header Access-Control-Allow-Methods "GET,HEAD,OPTIONS";
-        add_header Access-Control-Request-Headers "*";
+        add_header Access-Control-Allow-Headers "Accept, Accept-Encoding, Access-Control-Allow-Credentials, Access-Control-Allow-Headers, Access-Control-Allow-Methods, Access-Control-Allow-Origin, Access-Control-Max-Age, Age, Allow,Authentication-Info, Authorization, CONNECT, Cache-Control, Connection, Content-Base, Content-Length, Content-Location, Content-MD5, Content-Type, Content-Version, Cookie, DELETE, Destination, Expires, ETag, From, GET, HEAD, Host, Keep-Alive, Location, MIME-Version, OPTION, OPTIONS, Optional, Origin, POST, PUT, Protocol, Proxy-Authenticate, Proxy-Authentication-Info, Proxy-Authorization, Proxy-Features, Public, Referer, Refresh, Resolver-Location, Sec-Websocket-Extensions, Sec-Websocket-Key, Sec-Websocket-Origin, Sec-Websocket-Protocol, Sec-Websocket-Version, Security-Scheme, Server, Set-Cookie, et-Cookie2, SetProfile, Status, Timeout, Title, URI, User-Agent, Version, WWW-Authenticate, X-Content-Duration, X-Content-Security-Policy, X-Content-Type-Options, X-CustomHeader, X-DNSPrefetch-Control, X-Forwarded-For, X-Forwarded-Port, X-Forwarded-Proto, X-Frame-Options, X-Modified, X-OTHER, X-PING, X-Requested-With";
     }
 
     location ~ ^/content(.*)$ {


### PR DESCRIPTION
This PR:

* Mounts storage for the `nginx` container
* Serves files through NGINX, not through express
* Adds `Cache-Control: public, immutable, max-age`
* Adds `Content-type: application/wasm` to avoid downstream proxies avoiding compression