### PR TITLE
Add postgres to Catalysts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/.DS_Store
 local/certbot/conf/**
 local/nginx/conf.d/00-katalyst.conf
+.env-database-*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,20 @@ services:
         max-size: "100M"
         max-file: "10"
 
+  postgress:
+    image: postgres
+    container_name: ${POSTGRES_HOST:-postgres}
+    env_file:
+      - .env-database-admin
+    expose:
+      - ${POSTGRES_PORT:-5432}
+    restart: always
+    volumes:
+      - "${CONTENT_SERVER_STORAGE}/database:/var/lib/postgresql/data"
+    logging:
+      options:
+        max-size: "100M"
+        max-file: "10"
 
   content-server:
     image: decentraland/katalyst:${DOCKER_TAG:-latest}
@@ -34,6 +48,8 @@ services:
     env_file:
       - .env
       - .env-advanced
+      - .env-database-admin
+      - .env-database-content
     ports:
       - "6969:6969"
     restart: always

--- a/init.sh
+++ b/init.sh
@@ -209,6 +209,28 @@ if ! [ -x "$(command -v docker-compose)" ]; then
   exit 1
 fi
 
+if ! [ -f ".env-database-admin" ]; then
+    ROOT_USER=$(cat /dev/urandom | env LC_CTYPE=C tr -dc a-z | head -c 16)
+    ROOT_PASSWORD=$(cat /dev/urandom | env LC_CTYPE=C tr -dc a-zA-Z0-9 | head -c 16)
+    echo "POSTGRES_USER=${ROOT_USER}" > .env-database-admin
+    echo "POSTGRES_PASSWORD=${ROOT_PASSWORD}" >> .env-database-admin
+    echo "POSTGRES_DB=postgres" >> .env-database-admin
+    echo "POSTGRES_HOST=postgres" >> .env-database-admin
+    echo "POSTGRES_PORT=5432" >> .env-database-admin
+fi
+
+source ".env-database-admin"
+
+if ! [ -f ".env-database-content" ]; then
+    USER=$(cat /dev/urandom | env LC_CTYPE=C tr -dc a-z | head -c 16)
+    PASSWORD=$(cat /dev/urandom | env LC_CTYPE=C tr -dc a-zA-Z0-9 | head -c 16)
+    echo "POSTGRES_CONTENT_USER=${USER}" > .env-database-content
+    echo "POSTGRES_CONTENT_PASSWORD=${PASSWORD}" >> .env-database-content
+    echo "POSTGRES_CONTENT_DB=content" >> .env-database-content
+fi
+
+source ".env-database-content"
+
 docker pull decentraland/katalyst:${DOCKER_TAG}
 if test $? -ne 0; then
   echo -n "Failed to stop nginx! "


### PR DESCRIPTION
This PR adds psql to catalysts. The `init.sh` script will generate two different env files. The first has the login info for the root user, while the second one has the login information for the content server database and user.

The database files will be stored on the same storage folder as the content server files