### PR TITLE
chore: fix postgres version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
         max-file: "10"
 
   postgress:
-    image: postgres
+    image: postgres:12
     container_name: ${POSTGRES_HOST:-postgres}
     env_file:
       - .env-database-admin


### PR DESCRIPTION
We are now specifying the postgres version, to avoid unwanted version updates and incompatibilities