### PR TITLE
fix: update lambdas metrics port

### DIFF
--- a/local/nginx/include/upstream.conf
+++ b/local/nginx/include/upstream.conf
@@ -19,7 +19,7 @@ upstream content_metrics {
 }
 
 upstream lambdas_metrics {
-    server lambdas:7070;
+    server lambdas:9090;
 }
 
 upstream system_metrics {


### PR DESCRIPTION
The default port is 9090, as defined [here](https://github.com/decentraland/catalyst/blob/3a15f2e4f94ae8034a5e765247b75eceedb1c4f3/commons/servers/metrics.ts#L23)