### PR TITLE
feat: log slow queries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,7 @@ services:
     restart: always
     shm_size: 2560MB
     command: >
-      -c logging_collector=on
-      -c log_destination=stderr
+      -c log_min_duration_statement=800
       -c shared_buffers=2560MB
       -c effective_cache_size=7680MB
       -c maintenance_work_mem=640MB


### PR DESCRIPTION
We are doing 2 changes here:
1. We are now logging queries that take longer than 800ms
2. We are disabling the logging_collector, since it would send logs to a file inside the docker container