### PR TITLE
Update routes.conf to expose X-Forwarded-Host header in lambdas

### DIFF
--- a/local/nginx/include/routes.conf
+++ b/local/nginx/include/routes.conf
@@ -5,6 +5,7 @@ location ~ ^/content/(.*)$ {
     proxy_send_timeout          600;
     proxy_read_timeout          600;
     send_timeout                600;
+    proxy_set_header X-Forwarded-Host  $host;
 }
 
 location  ~ ^/comms/(.*)$ {

--- a/local/nginx/include/routes.conf
+++ b/local/nginx/include/routes.conf
@@ -18,6 +18,7 @@ location  ~ ^/comms/(.*)$ {
 location  ~ ^/lambdas/(.*)$ {
     proxy_pass http://lambdas/$1$is_args$args;
     proxy_pass_request_headers  on;
+    proxy_set_header X-Forwarded-Host  $host;
 }
 
 location / {


### PR DESCRIPTION
Add configuration for nginx to expose 'X-Forwarded-Host' header.