### PR TITLE
fix: add restart always to cadvisor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,6 +128,7 @@ services:
     image: gcr.io/google_containers/cadvisor:v0.35.0
     container_name: cadvisor
     command: --docker_only=true --disable_root_cgroup_stats=true
+    restart: always
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:ro


### PR DESCRIPTION
We were missing the `restart:always` in cadvisor. Since nginx depends on it, we need it to be up