### PR TITLE
fix: expose instead of publish

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       - .env-advanced
     environment:
       - LIGHTHOUSE_STORAGE_LOCATION=/app/storage/lighthouse
-    ports:
-      - "9000:9000"
+    expose:
+      - "9000"
     volumes:
       - "lighthouse_storage_volume:/app/storage/lighthouse"
     restart: always
@@ -96,8 +96,8 @@ services:
       - .env-database-content
     depends_on:
       - postgres
-    ports:
-      - "6969:6969"
+    expose:
+      - "6969"
     restart: always
     volumes:
       - "${CONTENT_SERVER_STORAGE}:/app/storage/content_server/"
@@ -117,8 +117,8 @@ services:
     env_file:
       - .env
       - .env-advanced
-    ports:
-      - "7070:7070"
+    expose:
+      - "7070"
     logging:
       driver: syslog
       options: { tag: lambdas }


### PR DESCRIPTION
For some reason, we were publishing the different services to the host. The servers didn't allow traffic through those ports, so there wasn't any security risks, but we shouldn't rely on server configuration.

Now, instead of publishing the ports to the host, we are simply exposing them