### PR TITLE
Increase work mem

### DIFF
--- a/local/postgres/postgresql.conf
+++ b/local/postgres/postgresql.conf
@@ -129,7 +129,7 @@ shared_buffers = 2560MB
 # Caution: it is not advisable to set max_prepared_transactions nonzero unless
 # you actively intend to use prepared transactions.
 #work_mem = 4MB				# min 64kB
-work_mem = 64MB
+work_mem = 128MB
 #maintenance_work_mem = 64MB		# min 1MB
 maintenance_work_mem = 640MB
 #autovacuum_work_mem = -1		# min 1MB, or -1 to use maintenance_work_mem


### PR DESCRIPTION
Increase work mem based on the findings of @abarmat 

By increasing the `work_mem` it uses `Sort Method: quicksort  Memory: 103173kB`  instead of a less efficient `Sort Method: external merge  Disk: 63072kB`

```sql
EXPLAIN ANALYZE SELECT entity_id, entity_pointers, date_part('epoch', local_timestamp) * 1000 AS local_timestamp FROM deployments WHERE entity_type = 'profile' AND deleter_deployment IS NULL ORDER BY local_timestamp DESC, LOWER(entity_id) DESC;
```