### PR TITLE
Add rate limit

### DIFF
--- a/local/nginx/conf.d/katalyst-http.conf.template
+++ b/local/nginx/conf.d/katalyst-http.conf.template
@@ -1,11 +1,10 @@
 rewrite_log on;
 
 include /etc/nginx/include/upstream.conf;
+include /etc/nginx/include/rates.conf;
 
 
 server {
-    limit_req_dry_run  on;
-
     listen 80 reuseport;
     
     server_name $katalyst_host;

--- a/local/nginx/conf.d/katalyst-https.conf.template
+++ b/local/nginx/conf.d/katalyst-https.conf.template
@@ -1,9 +1,9 @@
 rewrite_log on;
 
 include /etc/nginx/include/upstream.conf;
+include /etc/nginx/include/rates.conf;
 
 server {
-    limit_req_dry_run  on;
     
     listen 80 reuseport;
     server_name $katalyst_host;
@@ -22,7 +22,6 @@ server {
 
 
 server {
-    limit_req_dry_run  on;
     
     listen 443 reuseport ssl http2;
     server_name $katalyst_host;

--- a/local/nginx/include/comms.conf
+++ b/local/nginx/include/comms.conf
@@ -1,4 +1,14 @@
-# Tier A
+# Endpoint to be deprecated
+location  ~ ^/comms/(peers|islands)(.*)$ {
+    include /etc/nginx/include/comms_proxy.conf;
+
+    limit_req zone=tier_b burst=8 nodelay;
+
+    proxy_pass http://comms-server/$1$2$is_args$args;
+}
+
+
+# Default
 location  ~ ^/comms/(.*)$ {
     include /etc/nginx/include/comms_proxy.conf;
 

--- a/local/nginx/include/content.conf
+++ b/local/nginx/include/content.conf
@@ -1,3 +1,11 @@
+# Endpoint to be deprecated
+location ~ ^/content/(deployments)(.*)$ {
+    include /etc/nginx/include/content_proxy.conf;
+
+    limit_req zone=tier_c burst=2 nodelay;
+
+    proxy_pass http://content-server/$1$2$is_args$args;
+}
 
 
 # Default Tier

--- a/local/nginx/include/rates.conf
+++ b/local/nginx/include/rates.conf
@@ -1,0 +1,3 @@
+
+limit_req_zone $uri zone=tier_b:10m rate=30r/m;
+limit_req_zone $uri zone=tier_c:10m rate=5r/m;

--- a/local/nginx/include/rates.conf
+++ b/local/nginx/include/rates.conf
@@ -1,3 +1,3 @@
 
-limit_req_zone $uri zone=tier_b:10m rate=30r/m;
+limit_req_zone $uri zone=tier_b:10m rate=40r/m;
 limit_req_zone $uri zone=tier_c:10m rate=5r/m;


### PR DESCRIPTION
Added rate limit to the following endpoints:
- `/content/deployments` (5 requests per minute per catalyst)
- `/comms/peers` (40 requests per minute per catalyst)
- `/comms/islands` (40 requests per minute per catalyst)
