### PR TITLE
feat: add maintenance mode

### DIFF
--- a/docker-compose-maintenance.yml
+++ b/docker-compose-maintenance.yml
@@ -1,0 +1,70 @@
+version: "3"
+
+volumes:
+  content_server_storage: {}
+
+services:
+  postgres:
+    image: postgres:12
+    container_name: ${POSTGRES_HOST:-postgres}
+    env_file:
+      - .env-database-admin
+      - .env-database-content
+    expose:
+      - ${POSTGRES_PORT:-5432}
+    restart: always
+    shm_size: 2560MB
+    volumes:
+      - "${CONTENT_SERVER_STORAGE}/database:/var/lib/postgresql/data"
+      - "./local/postgres/custom-entrypoint.sh:/usr/local/bin/custom-entrypoint.sh:ro"
+      - "./local/postgres/postgresql.conf:/etc/postgresql/postgresql.conf"
+      - "./local/postgres/scripts/always:/always-initdb.d:ro"
+      - "./local/postgres/scripts/initial:/docker-entrypoint-initdb.d:ro"
+    command: custom-entrypoint.sh -c config_file=/etc/postgresql/postgresql.conf
+    # logging:
+    #   driver: syslog
+    #   options: { tag: postgres }
+
+  postgres-exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter
+    container_name: postgres-exporter
+    environment:
+      - PG_EXPORTER_EXTEND_QUERY_PATH=/etc/postgres-exporter/queries.yaml
+    env_file:
+      - .env-database-metrics
+    volumes:
+      - ./local/postgres-exporter:/etc/postgres-exporter
+    restart: always
+    depends_on:
+      - postgres
+    shm_size: 512mb
+    # logging:
+    #   driver: syslog
+    #   options: { tag: postgres-exporter }
+
+  content-server:
+    image: decentraland/catalyst-content:${DOCKER_TAG:-latest}
+    working_dir: /app
+    command: [ "/usr/local/bin/node", "--max-old-space-size=8192", "content/entrypoints/run-maintenance.js" ]
+    restart: "no"
+    environment:
+      - LOG_REQUESTS=false # Request logs are produced by NGINX
+      - CONTENT_SERVER_ADDRESS=${CATALYST_URL}/content/
+      - STORAGE_ROOT_FOLDER=/app/storage/content_server/
+      - BOOTSTRAP_FROM_SCRATCH=${BOOTSTRAP_FROM_SCRATCH:-false}
+      - POSTGRES_HOST=${POSTGRES_HOST:-postgres}
+      - POSTGRES_PORT=${POSTGRES_PORT:-5432}
+      - PG_QUERY_TIMEOUT=300000
+    env_file:
+      - .env
+      - .env-advanced
+      - .env-database-content
+    depends_on:
+      - postgres
+    expose:
+      - "6969"
+    volumes:
+      - "${CONTENT_SERVER_STORAGE}:/app/storage/content_server/"
+    # logging:
+    #   driver: syslog
+    #   options: { tag: content-server }

--- a/init.sh
+++ b/init.sh
@@ -218,6 +218,7 @@ export DOCKER_TAG=${DOCKER_TAG:-latest}
 export LIGHTHOUSE_DOCKER_TAG=${LIGHTHOUSE_DOCKER_TAG:-latest}
 REGENERATE=${REGENERATE:-0}
 SLEEP_TIME=${SLEEP_TIME:-5}
+MAINTENANCE_MODE=${MAINTENANCE_MODE:-0}
 
 if [ "$DOCKER_TAG" != "latest" ]; then
     echo -e "\033[33m WARNING: You are not running latest image of Catalyst's Content and Catalyst's Lambdas Nodes. \033[39m"
@@ -375,11 +376,16 @@ fi
 
 echo "## Restarting containers... "
 docker-compose down
-docker-compose -f docker-compose.yml -f "platform.$(uname -s).yml" up -d nginx
-
-if test $? -ne 0; then
-  echo -n "Failed to start catalyst node"
-  printMessage failed
-  exit 1
+if test ${MAINTENANCE_MODE} -eq 1; then
+  echo 'Running maintenance...'
+  docker-compose -f docker-compose-maintenance.yml up --abort-on-container-exit
+else
+  docker-compose -f docker-compose.yml -f "platform.$(uname -s).yml" up -d nginx
+  if test $? -ne 0; then
+    echo -n "Failed to start catalyst node"
+    printMessage failed
+    exit 1
+  fi
+  echo "## Catalyst server is up and running at $CATALYST_URL"
 fi
-echo "## Catalyst server is up and running at $CATALYST_URL"
+


### PR DESCRIPTION
This PR introduces the capability of run the Catalyst in Maintenance mode, in which it is run some maintenance tasks and then exits. For now, those tasks are two: migrate content files to new structure and delete unreferenced (no entries in db) files in the content folder.