### PR TITLE
fix: change fallback latest docker tag on init.sh

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -300,23 +300,23 @@ if [ -z "$POSTGRES_PASSWORD" ]; then
   exit 1
 fi
 
-docker pull "decentraland/catalyst-content:${DOCKER_TAG:latest}"
+docker pull "decentraland/catalyst-content:${DOCKER_TAG:-latest}"
 if [ $? -ne 0 ]; then
-  echo -n "Failed to pull the content's docker image with tag ${DOCKER_TAG:latest}"
+  echo -n "Failed to pull the content's docker image with tag ${DOCKER_TAG:-latest}"
   printMessage failed
   exit 1
 fi
 
-docker pull "decentraland/catalyst-lambdas:${DOCKER_TAG:latest}"
+docker pull "decentraland/catalyst-lambdas:${DOCKER_TAG:-latest}"
 if [ $? -ne 0 ]; then
-  echo -n "Failed to pull the lambda's docker image with tag ${DOCKER_TAG:latest}"
+  echo -n "Failed to pull the lambda's docker image with tag ${DOCKER_TAG:-latest}"
   printMessage failed
   exit 1
 fi
 
-docker pull "decentraland/catalyst-lighthouse:${LIGHTHOUSE_DOCKER_TAG:latest}"
+docker pull "decentraland/catalyst-lighthouse:${LIGHTHOUSE_DOCKER_TAG:-latest}"
 if [ $? -ne 0 ]; then
-  echo -n "Failed to pull the lighthouse's docker image with tag ${LIGHTHOUSE_DOCKER_TAG:latest}"
+  echo -n "Failed to pull the lighthouse's docker image with tag ${LIGHTHOUSE_DOCKER_TAG:-latest}"
   printMessage failed
   exit 1
 fi


### PR DESCRIPTION
Change `${DOCKER_TAG:latest}` to `${DOCKER_TAG:-latest}`

`${DOCKER_TAG:latest}` should fail, but it doesn't just because we explicitly set a `DOCKER_TAG` value earlier in the file