### PR TITLE
feat: expose archipelago status

### DIFF
--- a/local/nginx/include/archipelago.conf
+++ b/local/nginx/include/archipelago.conf
@@ -1,0 +1,3 @@
+location /archipelago/status {
+    proxy_pass http://archipelago/status;
+}

--- a/local/nginx/include/routes.conf
+++ b/local/nginx/include/routes.conf
@@ -10,3 +10,4 @@ include /etc/nginx/include/content.conf;
 include /etc/nginx/include/comms.conf;
 include /etc/nginx/include/lambdas.conf;
 include /etc/nginx/include/explorer_bff.conf;
+include /etc/nginx/include/archipelago.conf;


### PR DESCRIPTION
Expose archipelago status through the endpoint `/archipelago/status`

Payload example:

```
{
  "commitHash":"525a64efaa4e48d0652a2f1edfe47c3214465b38"
}
```

It helps with monitoring the status and current version of the service, as in https://catalyst-monitor.vercel.app