### PR TITLE
feat: revert exposing archipelago status

### DIFF
--- a/local/nginx/include/archipelago.conf
+++ b/local/nginx/include/archipelago.conf
@@ -1,3 +1,0 @@
-location /archipelago/status {
-    proxy_pass http://archipelago/status;
-}

--- a/local/nginx/include/routes.conf
+++ b/local/nginx/include/routes.conf
@@ -10,4 +10,3 @@ include /etc/nginx/include/content.conf;
 include /etc/nginx/include/comms.conf;
 include /etc/nginx/include/lambdas.conf;
 include /etc/nginx/include/explorer_bff.conf;
-include /etc/nginx/include/archipelago.conf;


### PR DESCRIPTION
Revert https://github.com/decentraland/catalyst-owner/pull/135

Archipelago status will be exposed through BFF, preventing direct exposure of an internal service