### PR TITLE
fix: realm name expansion

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - "CONTENT_URL=http://content-server:6969"
       - "LIGHTHOUSE_URL=http://comms-server:9000"
       - STORAGE_LOCATION=/app/storage
-      - REALM_NAMES=${REALM_NAMES:-$LIGHTHOUSE_NAMES}
+      - REALM_NAMES=${LIGHTHOUSE_NAMES}
     restart: always
     expose:
       - "3000"


### PR DESCRIPTION

with `${REALM_NAMES:-$LIGHTHOUSE_NAMES}`, if LIGHTHOUSE_NAMES is not defined, docker-compose will end up expanding to `"$LIGHTHOUSE_NAMES"` for some reason (this doesn't happen in bash), so I decided to simplify and just use LIGHTHOUSE_NAMES directly

