### PR TITLE
chore: expose lamb2 host url on bff to hit /status endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - CONTENT_URL=${CATALYST_URL}/content/
       - BFF_PUBLIC_URL=/bff
       - HEALTHCHECK_LAMBDAS_URL=http://lambdas:7070
+      - HEALTHCHECK_LAMB2_URL=http://lamb2:7272
       - HEALTHCHECK_CONTENT_URL=http://content-server:6969
       - COMMS_MODE=archipelago
       - STORAGE_LOCATION=/app/storage


### PR DESCRIPTION
Expose lamb2 host url on BFF so it can hit /status endpoint whenever a request to /about is received.

This is part of the work needed to enhance the realm picking algorithm.