### PR TITLE
chore: remove unused lamb2 host as bff env variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,6 @@ services:
       - CONTENT_URL=${CATALYST_URL}/content/
       - BFF_PUBLIC_URL=/bff
       - HEALTHCHECK_LAMBDAS_URL=http://lambdas:7070
-      - HEALTHCHECK_LAMB2_URL=http://lamb2:7272
       - HEALTHCHECK_CONTENT_URL=http://content-server:6969
       - COMMS_MODE=archipelago
       - STORAGE_LOCATION=/app/storage


### PR DESCRIPTION
We don't want to expose lamb2 to the world since it is a in-progress migration of lambdas. Please refer to this PR's comments for more information -> https://github.com/decentraland/protocol/pull/127