### PR TITLE
chore: Lambdas migration

### DIFF
--- a/local/nginx/include/lambdas.conf
+++ b/local/nginx/include/lambdas.conf
@@ -22,9 +22,11 @@ location ~ ^/lambdas/users/(.*)$ {
     proxy_pass http://lamb2/users/$1$is_args$args;
 }
 
-location ~ ^/lambdas/profiles(.*)$ {
+
+location ~ ^/lambdas/collections$ {
     include /etc/nginx/include/lamb2_proxy.conf;
-    proxy_pass http://$profiles_service/profiles$1$is_args$args;
+
+    proxy_pass http://lamb2/nfts/collections$is_args$args;
 }
 
 location ~ ^/lambdas/collections/contents/(.*)/image$ {

--- a/local/nginx/include/lambdas.conf
+++ b/local/nginx/include/lambdas.conf
@@ -27,6 +27,24 @@ location ~ ^/lambdas/profiles(.*)$ {
     proxy_pass http://$profiles_service/profiles$1$is_args$args;
 }
 
+location ~ ^/lambdas/collections/contents/(.*)/image$ {
+    include /etc/nginx/include/content_proxy.conf;
+
+    proxy_pass http://content-server/queries/items/$1/image;
+}
+
+location ~ ^/lambdas/collections/contents/(.*)/thumbnail {
+    include /etc/nginx/include/content_proxy.conf;
+
+    proxy_pass http://content-server/queries/items/$1/thumbnail;
+}
+
+location ~ ^/lambdas/collections/standard/erc721/(.*)$ {
+    include /etc/nginx/include/content_proxy.conf;
+
+    proxy_pass http://content-server/queries/erc721/$1$is_args$args;
+}
+
 location ~ ^/lambdas/(.*)$ {
     include /etc/nginx/include/lambdas_proxy.conf;
 

--- a/local/nginx/include/lambdas.conf
+++ b/local/nginx/include/lambdas.conf
@@ -22,6 +22,23 @@ location ~ ^/lambdas/users/(.*)$ {
     proxy_pass http://lamb2/users/$1$is_args$args;
 }
 
+location ~ ^/lambdas/profiles/$ {
+    include /etc/nginx/include/lamb2_proxy.conf;
+
+    proxy_pass http://lambdas/profiles/$1$is_args$args;
+}
+
+location ~ ^/lambdas/profiles/(.*)$ {
+    include /etc/nginx/include/lamb2_proxy.conf;
+
+    proxy_pass http://lamb2/profiles/$1$is_args$args;
+}
+
+location ~ ^/lambdas/profiles(.*)$ {
+    include /etc/nginx/include/lamb2_proxy.conf;
+
+    proxy_pass http://$profiles_service/profiles$1$is_args$args;
+}
 
 location ~ ^/lambdas/collections$ {
     include /etc/nginx/include/lamb2_proxy.conf;


### PR DESCRIPTION
Those are test running with this branch running on peer-testing-4:

# /lambdas/collections/contents/:urn/image

```
http 'https://peer-testing-3.decentraland.org/lambdas/collections/contents/urn:decentraland:matic:collections-v2:0x08d131cfa304c3b47f9c57f95e6c4e5548d25bb4:0/image' > image.0
http 'https://peer-testing-4.decentraland.org/lambdas/collections/contents/urn:decentraland:matic:collections-v2:0x08d131cfa304c3b47f9c57f95e6c4e5548d25bb4:0/image' > image.1
http 'https://peer-testing-4.decentraland.org/content/queries/items/urn:decentraland:matic:collections-v2:0x08d131cfa304c3b47f9c57f95e6c4e5548d25bb4:0/image' > image.2
```
# /lambdas/collections/contents/:urn/thumbnail

```
http 'https://peer-testing-3.decentraland.org/lambdas/collections/contents/urn:decentraland:matic:collections-v2:0x08d131cfa304c3b47f9c57f95e6c4e5548d25bb4:0/thumbnail' > thumbnail.0
http 'https://peer-testing-4.decentraland.org/lambdas/collections/contents/urn:decentraland:matic:collections-v2:0x08d131cfa304c3b47f9c57f95e6c4e5548d25bb4:0/thumbnail' > thumbnail.1
http 'https://peer-testing-4.decentraland.org/content/queries/items/urn:decentraland:matic:collections-v2:0x08d131cfa304c3b47f9c57f95e6c4e5548d25bb4:0/thumbnail' > thumbnail.2
```

# /lambdas/standard/erc721/:chainId/:contract/:option/:emission?

```
http https://peer-testing-3.decentraland.org/lambdas/collections/standard/erc721/1/halloween_2020/hwn_2020_ghostblaster_upper_body/230 > erc721.0
http https://peer-testing-4.decentraland.org/lambdas/collections/standard/erc721/1/halloween_2020/hwn_2020_ghostblaster_upper_body/230 > erc721.1
http https://peer-testing-4.decentraland.org/content/queries/erc721/1/halloween_2020/hwn_2020_ghostblaster_upper_body/230 > erc721.2
```

# /lambdas/collections
```
http https://peer-testing-4.decentraland.org/lambdas/collections > collections.0
http https://peer-testing-3.decentraland.org/lambdas/collections > collections.1
```

# /lambdas/profiles/:id
```
http https://peer-testing-4.decentraland.org/lambdas/profiles/0xb7DF441676bf3bDb13ad622ADE983d84f86B0df4 > profile.0
http https://peer-testing-3.decentraland.org/lambdas/profiles/0xb7DF441676bf3bDb13ad622ADE983d84f86B0df4 > profile.1
diff <(jq --sort-keys . profile.0) <(jq --sort-keys . profile.1)
```

# /lambdas/profiles?id= still works

```
http https://peer-testing-4.decentraland.org/lambdas/profiles?id=0xb7DF441676bf3bDb13ad622ADE983d84f86B0df4
http https://peer-testing-4.decentraland.org/lambdas/profiles/?id=0xb7DF441676bf3bDb13ad622ADE983d84f86B0df4
```
