### PR TITLE
Add reverse-proxy with CORS Access-Control-Allow-Origin for PlutoTV

### DIFF
--- a/local/nginx/include/plutotv.conf
+++ b/local/nginx/include/plutotv.conf
@@ -1,0 +1,7 @@
+location ~ /plutotv/ {
+  include /etc/nginx/include/plutotv_proxy.conf;
+
+  rewrite /plutotv/(.*) /$1 break;
+
+  proxy_pass http://stitcher-ipv4.pluto.tv;
+}

--- a/local/nginx/include/plutotv_proxy.conf
+++ b/local/nginx/include/plutotv_proxy.conf
@@ -1,7 +1,6 @@
 
 proxy_hide_header 'Access-Control-Allow-Origin';
-add_header 'Access-Control-Allow-Origin' 'http://localhost:8080';
+add_header 'Access-Control-Allow-Origin' 'http://${CATALYST_URL}:8080';
 
 add_header 'Cache-Control' 'no-cache, no-store';
-
 add_header 'Pragma' 'no-cache';

--- a/local/nginx/include/plutotv_proxy.conf
+++ b/local/nginx/include/plutotv_proxy.conf
@@ -1,0 +1,7 @@
+
+proxy_hide_header 'Access-Control-Allow-Origin';
+add_header 'Access-Control-Allow-Origin' 'http://localhost:8080';
+
+add_header 'Cache-Control' 'no-cache, no-store';
+
+add_header 'Pragma' 'no-cache';


### PR DESCRIPTION
To be used with
`VideoPlayer.create(entity, { src: 'http://localhost/plutotv/v1/stitch/...' })`
in order to reach
`https://stitcher-ipv4.pluto.tv/v1/stitch/...`