### PR TITLE
fix: Inter-catalyst connections blocked due to CORS (#224)

### DIFF
--- a/local/nginx/nginx.conf
+++ b/local/nginx/nginx.conf
@@ -37,5 +37,7 @@ http {
         POST lamb2;
     }
 
+    add_header 'Access-Control-Allow-Origin' '$http_origin' always;
+
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
For fixing https://github.com/decentraland/catalyst-owner/issues/224.

Only this one line needs to be added, according to https://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header.

`$http_origin` works on `Heroku`; on catalysts, it may be that `$CATALYST_URL` should be used instead.

Not sure how best to test this.