### PR TITLE
refactor: remove old lambdas service (full-realm)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,12 +78,12 @@ jobs:
             sleep 10
           done
 
-      - name: wait for lambdas
+      - name: wait for lamb2
         timeout-minutes: 2
         run: |
           until ./.github/workflows/check-http-status-code.sh ${{ matrix.catalyst_url }}/lambdas/status 200; do
             echo "Retrying in 10 seconds..."
-            docker-compose logs lambdas
+            docker-compose logs lamb2
             sleep 10
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,6 @@ jobs:
         if: ${{ always() }}
         run: ./.github/workflows/check-http-status-code.sh ${{ matrix.catalyst_url }}/node_metrics 200 -u test-user:test-password
 
-      - name: test lambdas_metrics auth, must be 401
-        if: ${{ always() }}
-        run: ./.github/workflows/check-http-status-code.sh ${{ matrix.catalyst_url }}/lambdas_metrics 401
       - name: test lamb2_metrics auth, must be 401
         if: ${{ always() }}
         run: ./.github/workflows/check-http-status-code.sh ${{ matrix.catalyst_url }}/lamb2_metrics 401
@@ -125,9 +122,6 @@ jobs:
         if: ${{ always() }}
         run: htpasswd -bc local/nginx/auth/.htpasswd-metrics test-user2 test-password2
 
-      - name: test lambdas_metrics auth, must be 200
-        if: ${{ always() }}
-        run: ./.github/workflows/check-http-status-code.sh ${{ matrix.catalyst_url }}/lambdas_metrics 200 -u test-user2:test-password2
       - name: test lamb2_metrics auth, must be 200
         if: ${{ always() }}
         run: ./.github/workflows/check-http-status-code.sh ${{ matrix.catalyst_url }}/lamb2_metrics 200 -u test-user2:test-password2

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ After you have configured everything, all you need to do is run:
 Once you started your Catalyst server, after a few seconds you should be able to test the different services by accessing:
 
 - Content: `CATALYST_URL/content/status`
-- Lambdas: `CATALYST_URL/lambdas/status`
+- Lamb2: `CATALYST_URL/lambdas/status`
 
 ## Updating your Catalyst
 
@@ -84,7 +84,7 @@ To stop a specific container on your node:
 To stop a specific container on your node:
 
 ```
-./stop.sh [ nginx | lambdas | content-server | archipelago | nats | nats-exporter ]
+./stop.sh [ nginx | lamb2 | content-server | archipelago | nats | nats-exporter ]
 ```
 
 ## [FAQ](https://github.com/decentraland/catalyst-owner/blob/master/docs/FAQ.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3"
 volumes:
   content_server_storage: {}
   nginx_storage: {}
-  lambdas_server_storage: {}
   shared_keys:
 
 services:
@@ -174,33 +173,6 @@ services:
       driver: syslog
       options: { tag: content-server }
 
-  lambdas:
-    image: quay.io/decentraland/catalyst:${DOCKER_TAG:-latest}
-    command:
-      [
-        "/usr/local/bin/node",
-        "--max-old-space-size=8192",
-        "lambdas/entrypoints/run-server.js",
-      ]
-    working_dir: /app
-    restart: always
-    environment:
-      - LOG_REQUESTS=false # Request logs are produced by NGINX
-      - CONTENT_SERVER_ADDRESS=${CATALYST_URL}/content/
-      - LAMBDAS_STORAGE_LOCATION=/app/storage/lambdas
-      - "COMMS_PROTOCOL=v3"
-    env_file:
-      - .env
-      - .env-advanced
-    expose:
-      - "7070"
-      - "9090"
-    logging:
-      driver: syslog
-      options: { tag: lambdas }
-    volumes:
-      - "lambdas_server_storage:/app/storage/lambdas"
-
   lamb2:
     image: quay.io/decentraland/lamb2:${LAMB2_DOCKER_TAG:-latest}
     working_dir: /app
@@ -210,7 +182,7 @@ services:
       - LAMBDAS_URL=${CATALYST_URL}/lambdas/
       - ARCHIPELAGO_URL=${CATALYST_URL}/archipelago/
       - CONTENT_URL=${CATALYST_URL}/content/
-      - INTERNAL_LAMBDAS_URL=http://lambdas:7070
+      - INTERNAL_LAMBDAS_URL=http://lamb2:7272
       - INTERNAL_ARCHIPELAGO_URL=http://archipelago:5000
       - INTERNAL_CONTENT_URL=http://content-server:6969
       - REALM_NAME=${REALM_NAME}
@@ -238,7 +210,6 @@ services:
       - /dev/disk/:/dev/disk:ro
     depends_on:
       - content-server
-      - lambdas
       - archipelago
 
   nginx:
@@ -260,7 +231,6 @@ services:
       - shared_keys:/secrets
     restart: always
     depends_on:
-      - lambdas
       - lamb2
       - cadvisor
       - content-server

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -3,7 +3,7 @@
 Metrics are exposed in the following endpoints:
 
 - `/content_metrics` - content server
-- `/lambdas_metrics` - lambdas
+- `/lamb2_metrics` - lamb2
 - `/system_metrics` - cadvisor
 - `/postgres_metrics` - postgres exporter
 - `/nats_metrics` - NATS exporter

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -57,9 +57,9 @@ Pointers are the ids or locations to which a Deployment belongs. Their format is
 
 The [Content Server](https://github.com/decentraland/catalyst/tree/main/content) is a part of the Catalyst node in charge of managing the Decentralized storage of Entitiy Deployments. Currently, all content stored in a Content Server is synchronized with the rest of the DAO Catalysts.
 
-### Lambdas
+### Lamb2
 
-The [Lambdas](https://github.com/decentraland/catalyst/tree/main/lambdas) Service is a part of the Catalyst node that works as a reconciliation layer between the Content Servers and the Blockchain, sanitizing content, validating ownership and helping retrieve information for the Catalyst clients.
+The [Lamb2](https://github.com/decentraland/lamb2) Service is a part of the Catalyst node that works as a reconciliation layer between the Content Servers and the Blockchain, sanitizing content, validating ownership and helping retrieve information for the Catalyst clients. It is exposed publicly under the `/lambdas/*` URL prefix for backward compatibility with existing clients.
 
 ### Synchronization 
 

--- a/local/nginx/include/lambdas.conf
+++ b/local/nginx/include/lambdas.conf
@@ -48,16 +48,10 @@ location ~ ^/lambdas/profile/(.*)$ {
     proxy_pass http://lamb2/profile/$1$is_args$args;
 }
 
-location ~ ^/lambdas/profiles/(.*)$ {
+location ~ ^/lambdas/profiles(/.*)?$ {
     include /etc/nginx/include/lamb2_proxy.conf;
 
-    proxy_pass http://lamb2/profiles/$1$is_args$args;
-}
-
-location ~ ^/lambdas/profiles(.*)$ {
-    include /etc/nginx/include/lamb2_proxy.conf;
-
-    proxy_pass http://$profiles_service/profiles$1$is_args$args;
+    proxy_pass http://lamb2/profiles$1$is_args$args;
 }
 
 location ~ ^/lambdas/outfits/(.*)$ {

--- a/local/nginx/include/lambdas.conf
+++ b/local/nginx/include/lambdas.conf
@@ -114,6 +114,18 @@ location ~ ^/lambdas/collections/wearables$ {
     proxy_pass http://lamb2/collections/wearables$is_args$args;
 }
 
+location ~ ^/lambdas/collections/emotes-by-owner/(.*)$ {
+    include /etc/nginx/include/lamb2_proxy.conf;
+
+    proxy_pass http://lamb2/collections/emotes-by-owner/$1$is_args$args;
+}
+
+location ~ ^/lambdas/collections/emotes$ {
+    include /etc/nginx/include/lamb2_proxy.conf;
+
+    proxy_pass http://lamb2/collections/emotes$is_args$args;
+}
+
 location ~ ^/lambdas/ {
     return 404;
 }

--- a/local/nginx/include/lambdas.conf
+++ b/local/nginx/include/lambdas.conf
@@ -6,8 +6,10 @@ location ~ ^/lambdas/contentv2/scenes {
     return 404;
 }
 
-location ~ ^/lambdas/contracts/denylisted-names {
-    return 404;
+location ~ ^/lambdas/status$ {
+    include /etc/nginx/include/lamb2_proxy.conf;
+
+    proxy_pass http://lamb2/status$is_args$args;
 }
 
 location ~ ^/lambdas/nfts/(.*)$ {
@@ -22,6 +24,12 @@ location ~ ^/lambdas/contracts/(.*)$ {
     proxy_pass http://lamb2/contracts/$1$is_args$args;
 }
 
+location ~ ^/lambdas/crypto/validate-signature$ {
+    include /etc/nginx/include/lamb2_proxy.conf;
+
+    proxy_pass http://lamb2/crypto/validate-signature$is_args$args;
+}
+
 location ~ ^/lambdas/users/(.*)$ {
     include /etc/nginx/include/lamb2_proxy.conf;
 
@@ -32,6 +40,12 @@ location ~ ^/lambdas/parcels/(.*)$ {
     include /etc/nginx/include/lamb2_proxy.conf;
 
     proxy_pass http://lamb2/parcels/$1$is_args$args;
+}
+
+location ~ ^/lambdas/profile/(.*)$ {
+    include /etc/nginx/include/lamb2_proxy.conf;
+
+    proxy_pass http://lamb2/profile/$1$is_args$args;
 }
 
 location ~ ^/lambdas/profiles/(.*)$ {
@@ -88,8 +102,18 @@ location ~ ^/lambdas/collections/standard/erc721/(.*)$ {
     proxy_pass http://content-server/queries/erc721/$1$is_args$args;
 }
 
-location ~ ^/lambdas/(.*)$ {
-    include /etc/nginx/include/lambdas_proxy.conf;
+location ~ ^/lambdas/collections/wearables-by-owner/(.*)$ {
+    include /etc/nginx/include/lamb2_proxy.conf;
 
-    proxy_pass http://lambdas/$1$is_args$args;
+    proxy_pass http://lamb2/collections/wearables-by-owner/$1$is_args$args;
+}
+
+location ~ ^/lambdas/collections/wearables$ {
+    include /etc/nginx/include/lamb2_proxy.conf;
+
+    proxy_pass http://lamb2/collections/wearables$is_args$args;
+}
+
+location ~ ^/lambdas/ {
+    return 404;
 }

--- a/local/nginx/include/lambdas_proxy.conf
+++ b/local/nginx/include/lambdas_proxy.conf
@@ -1,9 +1,0 @@
-
-proxy_pass_request_headers  on;
-# Security: forward client identity and connection info to upstream services
-# so they can perform accurate IP-based rate limiting, logging, and audit trails
-proxy_set_header Host              $host;
-proxy_set_header X-Real-IP         $remote_addr;
-proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-proxy_set_header X-Forwarded-Proto $scheme;
-proxy_set_header X-Forwarded-Host  $host;

--- a/local/nginx/include/metrics.conf
+++ b/local/nginx/include/metrics.conf
@@ -1,11 +1,3 @@
-location /lambdas_metrics {
-    auth_basic           "Prometheus metrics";
-    auth_basic_user_file /etc/nginx/auth/.htpasswd-metrics;
-
-    proxy_pass http://lambdas_metrics/metrics;
-    proxy_pass_request_headers  on;
-}
-
 location /lamb2_metrics {
     auth_basic           "Prometheus metrics";
     auth_basic_user_file /etc/nginx/auth/.htpasswd-metrics;

--- a/local/nginx/include/upstream.conf
+++ b/local/nginx/include/upstream.conf
@@ -10,16 +10,8 @@ upstream archipelago-core {
     server archipelago-core:5000;
 }
 
-upstream lambdas {
-    server lambdas:7070;
-}
-
 upstream lamb2 {
     server lamb2:7272;
-}
-
-upstream lambdas_metrics {
-    server lambdas:9090;
 }
 
 upstream system_metrics {

--- a/local/nginx/nginx.conf
+++ b/local/nginx/nginx.conf
@@ -50,9 +50,7 @@ http {
 
     # Needed for redirecting to lamb2/profiles
     map $request_method $profiles_service {
-        default lambdas;
-        GET lambdas;
-        POST lamb2;
+        default lamb2;
     }
 
     include /etc/nginx/conf.d/*.conf;

--- a/local/nginx/nginx.conf
+++ b/local/nginx/nginx.conf
@@ -48,10 +48,5 @@ http {
     gzip_proxied any;
     gzip_min_length 100000;
 
-    # Needed for redirecting to lamb2/profiles
-    map $request_method $profiles_service {
-        default lamb2;
-    }
-
     include /etc/nginx/conf.d/*.conf;
 }

--- a/platform.Darwin.yml
+++ b/platform.Darwin.yml
@@ -11,7 +11,6 @@ services:
   postgres-exporter: *COMMON
   node-exporter: *COMMON
   content-server: *COMMON
-  lambdas: *COMMON
   lamb2: *COMMON
   cadvisor: *COMMON
   nats: *COMMON

--- a/stop.sh
+++ b/stop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 VARIABLE_SUM=$#
 CONTAINER_NAMES=$@
-CONTAINER_VALID_LIST="nginx lambdas content-server archipelago nats nats-exporter stats"
+CONTAINER_VALID_LIST="nginx lamb2 content-server archipelago nats nats-exporter stats"
 
 printMessage () {
     Type=$1


### PR DESCRIPTION
## summary

full-realm port of decentraland/catalyst-owner#249. flips nginx routing for the remaining `/lambdas/*` paths to lamb2 and removes every connection to the deprecated lambdas service. paired with [decentraland/lamb2#462](https://github.com/decentraland/lamb2/pull/462) which adds the corresponding handlers in lamb2.

**deployment ordering:** the lamb2 pr must be merged and a new lamb2 image tagged before this is deployed - otherwise newly-routed paths will 502 until the lamb2 side is live.

## changes cherry-picked from refactor/remove-old-lambdas

- `ae110d0` refactor: remove old lambdas service
- `6f38dcf` refactor: route /lambdas/collections/emotes paths to lamb2
- `19b9901` refactor: drop stale lambdas service references

## full-realm conflict resolutions

- `docker-compose.yml`: kept `ARCHIPELAGO_URL`/`INTERNAL_ARCHIPELAGO_URL` env vars on lamb2 and the `archipelago` entry in `cadvisor.depends_on`; took the cherry-pick's `INTERNAL_LAMBDAS_URL=http://lamb2:7272` and removed the dead `lambdas` entry from `cadvisor.depends_on`.
- `local/nginx/include/upstream.conf`: kept the `archipelago` and `archipelago-core` upstreams; removed the dead `lambdas` upstream as in the cherry-pick.
- `stop.sh`: kept the full-realm-specific services (`archipelago nats nats-exporter stats`) in `container_valid_list` and swapped `lambdas` -> `lamb2`.
- `readme.md`: kept the full-realm-specific services in the `./stop.sh` example and swapped `lambdas` -> `lamb2`.

## nginx (`local/nginx/include/`)

- **`lambdas.conf`**:
  - new routes to lamb2 for `/lambdas/status`, `/lambdas/profile/:id`, `/lambdas/crypto/validate-signature`, `/lambdas/collections/wearables`, `/lambdas/collections/wearables-by-owner/:owner`, `/lambdas/collections/emotes`, `/lambdas/collections/emotes-by-owner/:owner`.
  - removed the explicit 404 on `/lambdas/contracts/denylisted-names` - the existing `/lambdas/contracts/(.*)` rule sends it to lamb2 which has it implemented.
  - replaced the catch-all `proxy_pass http://lambdas/` with `return 404`. legacy unported paths now 404 (`/lambdas/health`, `/contentv2/parcel_info`) - the org-wide caller search showed no live callers for any of them. `/lambdas/images/:cid/:size` was also a left-behind path; it has since been deleted upstream in [decentraland/catalyst#1920](https://github.com/decentraland/catalyst/pull/1920).
- **`upstream.conf`**: dropped the `lambdas` upstream (full-realm did not have `lambdas_metrics`).
- **`metrics.conf`**: dropped the `/lambdas_metrics` location.
- **`nginx.conf`**: collapsed the `\$profiles_service` map to always resolve to lamb2.
- deleted the now-unused `lambdas_proxy.conf` include.

## docker-compose.yml

- repointed `lamb2`'s `internal_lambdas_url` from `http://lambdas:7070` to `http://lamb2:7272` so lamb2's about-handler self-check keeps working.
- removed the dead `lambdas` entry from `cadvisor.depends_on`. (the `lambdas` service block itself was already absent on full-realm.)

## stale-reference cleanup

- `platform.darwin.yml`: dropped the `lambdas: *common` anchor.
- `stop.sh`: replaced `lambdas` with `lamb2` in `container_valid_list`.
- `.github/workflows/ci.yml`: renamed `wait for lambdas` to `wait for lamb2` and pointed `docker-compose logs` at the lamb2 container.
- `readme.md`: relabelled the status check entry to `lamb2` and updated the `./stop.sh` usage example.
- `docs/glossary.md`: rewrote the glossary entry to describe lamb2 and noted that `/lambdas/*` is preserved as a public url prefix for back-compat.

## ci and docs

- dropped the `/lambdas_metrics` auth checks from `.github/workflows/ci.yml` - the equivalent `/lamb2_metrics` checks already cover the surface.
- `docs/metrics.md` now lists `/lamb2_metrics` instead of `/lambdas_metrics`.

## external follow-up (out of repo)

- prometheus instances scraping production at `/lambdas_metrics` need to be repointed to `/lamb2_metrics`.
- dashboards or alerts filtering on `instance=...lambdas...` / `job=lambdas` will go silent. metric *families* overlap so name-based panels keep working.

## test plan

- [ ] `nginx -t` against the rendered config in a staging full-realm catalyst
- [ ] verify against a deployed full-realm catalyst:
  - [ ] `/lambdas/status` returns 200
  - [ ] `/lambdas/contracts/denylisted-names` returns the denylist (was 404)
  - [ ] `/lambdas/profile/<address>` returns the same body as `/lambdas/profiles/<address>`
  - [ ] `/lambdas/collections/wearables-by-owner/<address>` and `?includedefinitions`
  - [ ] `/lambdas/collections/wearables?textsearch=hat`
  - [ ] `/lambdas/collections/emotes-by-owner/<address>` and `?includedefinitions`
  - [ ] `/lambdas/collections/emotes?textsearch=dance`
  - [ ] `post /lambdas/crypto/validate-signature`
  - [ ] `/lambdas/health` returns 404
  - [ ] `/about` still reports `lambdas.healthy: true` and `comms` block reports archipelago status
  - [ ] `/lamb2_metrics` still scrapeable; `/lambdas_metrics` 404s
  - [ ] `./stop.sh lamb2` stops the lamb2 container
  - [ ] archipelago / nats / stats containers come up unchanged
  - [ ] ci passes (no more `/lambdas_metrics` step, `wait for lamb2` succeeds)