### PR TITLE
chore: update nginx to 1.31-alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,8 +136,7 @@ services:
 
   nginx:
     container_name: nginx
-    # Updated from 1.22-alpine to 1.28-alpine (latest stable) to patch known CVEs including CVE-2026-1642
-    image: nginx:1.28-alpine
+    image: nginx:1.31-alpine
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
## Summary
- Bump nginx Docker image from `1.28-alpine` to `1.31-alpine` in `docker-compose.yml`.
- Drop the stale inline comment that referenced the prior `1.22 → 1.28` bump.

## Test plan
- [ ] `docker-compose pull nginx` succeeds and resolves `nginx:1.31-alpine`.
- [ ] Start the stack locally and confirm nginx comes up and serves `/`, `/lambdas/*`, `/content/*`, `/stats/*` as before.
- [ ] CI passes (existing nginx readiness check in `.github/workflows/ci.yml`).