### PR TITLE
chore: update nginx to 1.31-alpine (full-realm)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,8 +214,7 @@ services:
 
   nginx:
     container_name: nginx
-    # Updated from 1.22-alpine to 1.28-alpine (latest stable) to patch known CVEs including CVE-2026-1642
-    image: nginx:1.28-alpine
+    image: nginx:1.31-alpine
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
## Summary
- Cherry-pick of #251 onto `full-realm`.
- Bump nginx Docker image from `1.28-alpine` to `1.31-alpine` in `docker-compose.yml`.

## Test plan
- [ ] `docker-compose pull nginx` succeeds and resolves `nginx:1.31-alpine`.
- [ ] Start the full-realm stack locally and confirm nginx comes up and serves requests as before.
- [ ] CI passes.