### PR TITLE
fix: repair certbot TLS config downloads + bump container images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,8 @@ services:
       options: { tag: postgres }
 
   postgres-exporter:
-    # Pinned to v0.19.1 by digest (was floating :latest)
-    image: quay.io/prometheuscommunity/postgres-exporter:v0.19.1@sha256:e96064f876226d94bb6ce48a4c4b3dd76edba91168ec1ab024e5c4b959310b0f
+    # Pinned to v0.20.1 by digest (was floating :latest)
+    image: quay.io/prometheuscommunity/postgres-exporter:v0.20.1@sha256:ac5ec343104fae0e2d84a27bb8d69b38430a11910c5382cad85d478d2bab713e
     container_name: postgres-exporter
     environment:
       - PG_EXPORTER_EXTEND_QUERY_PATH=/etc/postgres-exporter/queries.yaml
@@ -53,8 +53,8 @@ services:
       options: { tag: postgres-exporter }
 
   node-exporter:
-    # Pinned to v1.11.1 by digest (was floating :latest)
-    image: quay.io/prometheus/node-exporter:v1.11.1@sha256:0f422f62c15f154af8d8572b23d623aebfb10cec73a5c654d18f911f3f9df241
+    # Pinned to v1.12.1 by digest (was floating :latest)
+    image: quay.io/prometheus/node-exporter:v1.12.1@sha256:1b4e4438faca4dd7e001dd445d161a4a2091b0fededa84093b3a8dfeae1f1be0
     container_name: node-exporter
     restart: unless-stopped
     volumes:
@@ -142,7 +142,7 @@ services:
     container_name: nginx
     # Pinned by digest to guarantee the patched binary
     # (>= 1.31.1 fixes CVE-2026-9256, a heap overflow in ngx_http_rewrite_module)
-    image: nginx:1.31.1-alpine@sha256:8b1e78743a03dbb2c95171cc58639fef29abc8816598e27fb910ed2e621e589a
+    image: nginx:1.31.3-alpine@sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752
     ports:
       - "80:80"
       - "443:443"
@@ -169,8 +169,8 @@ services:
       options: { tag: nginx }
 
   certbot:
-    # Pinned to v5.6.0 by digest (was floating :latest)
-    image: certbot/certbot:v5.6.0@sha256:0107d084c225631fc64a8313e19adb07275f7296fde338f7dfa93986c80b2e3e
+    # Pinned to v5.7.0 by digest (was floating :latest)
+    image: certbot/certbot:v5.7.0@sha256:34ee91d2f43008eb78a007d22f23ed4b2eaa9a454cb27ca2c042b49527a695b4
     restart: always
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
     volumes:

--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 export rsa_key_size=4096
 export data_path="local/certbot"
+# Certbot release whose TLS config we download. Pinned (not "main") so a given
+# repo revision always fetches identical files; keep in sync with the certbot
+# container image tag in docker-compose.yml.
+export certbot_ref="v5.7.0"
 export nginx_server_file="local/nginx/conf.d/00-katalyst.conf"
 export nginx_server_template_http="local/nginx/conf.d/katalyst-http.conf.template"
 export nginx_server_template_https="local/nginx/conf.d/katalyst-https.conf.template"
@@ -12,22 +16,40 @@ export PATH="$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:
 # Functions
 #####
 
+# Download $1 to $2, atomically. Streams to a temp file in the target directory
+# and only moves it into place on success, so neither an HTTP error (--fail nets
+# the error body) nor an interrupted transfer can leave a partial/unparseable
+# file at the final path (which would make nginx fail to start). $3 is a label
+# for error messages.
+downloadTlsFile () {
+  local url="$1" target="$2" name="$3" tmp
+  tmp="$(mktemp "${target}.XXXXXX")" || {
+    echo -n "Failed to create temp file for $name... "
+    printMessage failed
+    exit 1
+  }
+  if curl -fsS "$url" -o "$tmp"; then
+    # mktemp creates the file 0600; these are public TLS config files, so restore
+    # the world-readable perms the previous `curl -o` produced before moving.
+    chmod 0644 "$tmp"
+    mv "$tmp" "$target"
+  else
+    rm -f "$tmp"
+    echo -n "Failed to download $name... "
+    printMessage failed
+    exit 1
+  fi
+}
+
 leCertEmit () {
   echo "## Downloading recommended TLS parameters ..."
   mkdir -p "$data_path/conf"
-  # --fail makes curl exit non-zero on HTTP errors (e.g. 404) instead of writing
-  # the error body into the file, which would leave nginx with an unparseable
-  # config ("unexpected end of file"). Write to the target only on success.
-  if ! curl -fsS https://raw.githubusercontent.com/certbot/certbot/main/certbot/src/certbot/_internal/plugins/nginx/tls_configs/options-ssl-nginx.conf -o "$data_path/conf/options-ssl-nginx.conf"; then
-    echo -n "Failed to download options-ssl-nginx.conf... "
-    printMessage failed
-    exit 1
-  fi
-  if ! curl -fsS https://raw.githubusercontent.com/certbot/certbot/main/certbot/src/certbot/ssl-dhparams.pem -o "$data_path/conf/ssl-dhparams.pem"; then
-    echo -n "Failed to download ssl-dhparams.pem... "
-    printMessage failed
-    exit 1
-  fi
+  downloadTlsFile \
+    "https://raw.githubusercontent.com/certbot/certbot/${certbot_ref}/certbot/src/certbot/_internal/plugins/nginx/tls_configs/options-ssl-nginx.conf" \
+    "$data_path/conf/options-ssl-nginx.conf" "options-ssl-nginx.conf"
+  downloadTlsFile \
+    "https://raw.githubusercontent.com/certbot/certbot/${certbot_ref}/certbot/src/certbot/ssl-dhparams.pem" \
+    "$data_path/conf/ssl-dhparams.pem" "ssl-dhparams.pem"
   echo
 
   echo " Creating dummy certificate for $nginx_url..."

--- a/init.sh
+++ b/init.sh
@@ -15,8 +15,19 @@ export PATH="$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:
 leCertEmit () {
   echo "## Downloading recommended TLS parameters ..."
   mkdir -p "$data_path/conf"
-  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
-  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  # --fail makes curl exit non-zero on HTTP errors (e.g. 404) instead of writing
+  # the error body into the file, which would leave nginx with an unparseable
+  # config ("unexpected end of file"). Write to the target only on success.
+  if ! curl -fsS https://raw.githubusercontent.com/certbot/certbot/main/certbot/src/certbot/_internal/plugins/nginx/tls_configs/options-ssl-nginx.conf -o "$data_path/conf/options-ssl-nginx.conf"; then
+    echo -n "Failed to download options-ssl-nginx.conf... "
+    printMessage failed
+    exit 1
+  fi
+  if ! curl -fsS https://raw.githubusercontent.com/certbot/certbot/main/certbot/src/certbot/ssl-dhparams.pem -o "$data_path/conf/ssl-dhparams.pem"; then
+    echo -n "Failed to download ssl-dhparams.pem... "
+    printMessage failed
+    exit 1
+  fi
   echo
 
   echo " Creating dummy certificate for $nginx_url..."


### PR DESCRIPTION
## Summary

Fixes the nginx startup failure during `./init.sh` and bumps digest-pinned container images to their latest releases.

### 1. `init.sh` — certbot TLS config download URLs (the actual bug)

Running `./init.sh` was failing with nginx crash-looping on:

```
[emerg] unexpected end of file, expecting ";" or "}" in /etc/letsencrypt/options-ssl-nginx.conf:1
```

**Root cause:** the certbot repo restructured its directory layout, so the raw GitHub URLs in `leCertEmit` now return **404**. Since `curl -s ... > file` does not fail on HTTP errors, the `404: Not Found` body was written into `options-ssl-nginx.conf`, and nginx choked parsing it.

**Fix:**
- Point both downloads at their current paths on the certbot `main` branch:
  - `options-ssl-nginx.conf` → `certbot/src/certbot/_internal/plugins/nginx/tls_configs/`
  - `ssl-dhparams.pem` → `certbot/src/certbot/`
- Switch to `curl -fsS ... -o`, so an HTTP error aborts `init.sh` with a clear message instead of silently writing an unparseable config.

### 2. `docker-compose.yml` — image updates

Bumped digest-pinned images to their latest releases. Each digest verified against its registry (tag → manifest digest).

| Service | Old | New |
|---|---|---|
| nginx | `1.31.1-alpine` | `1.31.3-alpine` |
| certbot | `v5.6.0` | `v5.7.0` |
| postgres-exporter | `v0.19.1` | `v0.20.1` |
| node-exporter | `v1.11.1` | `v1.12.1` |

**Intentionally unchanged:** `postgres:16` (the DB, as requested), `cadvisor` (already on the latest `v0.55.1`), and the DCL images (`catalyst`, `lamb2`) tagged via env vars.

## Testing

- Verified all new download URLs return real content (HTTP 200).
- Verified every new image digest resolves to its tag at the registry.
- Not yet smoke-tested with a live `docker-compose up`; `postgres-exporter` v0.20.0 was a minor bump, so worth a glance at its changelog if any dashboards depend on specific metric series.

---

## Update: metric-compatibility verified + review follow-ups

**Metric compatibility (checked against the Foundation's Prometheus rules repo).** Both exporter bumps were verified against every alert/recording rule that scrapes these targets:
- **postgres-exporter** v0.19.1 → v0.20.1: the only metric consumed is `pg_up` (a "Postgres down" alert), which is unaffected by the v0.20 collector refactor. The renamed `pg_replication_slot_*` → `pg_replication_slots_*` metrics and the collectors moved to standalone (`pg_settings`, `pg_stat_activity`, `pg_stat_archiver`, `pg_stat_replication`) are **not referenced anywhere**. No config change needed here (this service sets no collector flags, and `PG_EXPORTER_EXTEND_QUERY_PATH` is still supported).
- **node-exporter** v1.11.1 → v1.12.1: only `node_cpu_seconds_total`, `node_filesystem_size_bytes`, and `node_filesystem_free_bytes` are used; all `cpu`/`filesystem` metrics are unchanged in v1.12.x (changes were new collectors + unrelated bugfixes).

**Review follow-ups addressed (init.sh):**
- **P2 — reproducibility:** TLS config downloads are now pinned to the certbot **v5.7.0** release tag (new `certbot_ref` var, kept in sync with the certbot container image) instead of the mutable `main` branch, so a given repo revision always fetches identical files.
- **P2 — atomic writes:** downloads now stream to a temp file and are `mv`'d into place only on success. Combined with `curl --fail`, neither an HTTP error nor an interrupted transfer can leave a partial/error-body file where nginx would parse it. Verified with positive + 404 negative tests (no partial file, no temp leftover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
