### PR TITLE
fix: repair certbot TLS config downloads + bump container images (full-realm)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,8 @@ services:
       options: { tag: postgres }
 
   postgres-exporter:
-    image: quay.io/prometheuscommunity/postgres-exporter
+    # Pinned to v0.20.1 by digest (was floating :latest)
+    image: quay.io/prometheuscommunity/postgres-exporter:v0.20.1@sha256:ac5ec343104fae0e2d84a27bb8d69b38430a11910c5382cad85d478d2bab713e
     container_name: postgres-exporter
     environment:
       - PG_EXPORTER_EXTEND_QUERY_PATH=/etc/postgres-exporter/queries.yaml
@@ -126,7 +127,8 @@ services:
       options: { tag: postgres-exporter }
 
   node-exporter:
-    image: quay.io/prometheus/node-exporter:latest
+    # Pinned to v1.12.1 by digest (was floating :latest)
+    image: quay.io/prometheus/node-exporter:v1.12.1@sha256:1b4e4438faca4dd7e001dd445d161a4a2091b0fededa84093b3a8dfeae1f1be0
     container_name: node-exporter
     restart: unless-stopped
     volumes:
@@ -198,7 +200,8 @@ services:
       options: { tag: lamb2 }
 
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.55.1
+    # Pinned by digest to the v0.55.1 release for reproducible deploys
+    image: gcr.io/cadvisor/cadvisor:v0.55.1@sha256:3de2bd5203120b866d74a9b283b2ffb8ec382fbf9dc321814700c6ea6f44ec57
     container_name: cadvisor
     command: --docker_only=true --disable_root_cgroup_stats=true
     restart: always
@@ -214,7 +217,9 @@ services:
 
   nginx:
     container_name: nginx
-    image: nginx:1.31-alpine
+    # Pinned by digest to guarantee the patched binary
+    # (>= 1.31.1 fixes CVE-2026-9256, a heap overflow in ngx_http_rewrite_module)
+    image: nginx:1.31.3-alpine@sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752
     ports:
       - "80:80"
       - "443:443"
@@ -246,7 +251,8 @@ services:
       options: { tag: nginx }
 
   certbot:
-    image: certbot/certbot
+    # Pinned to v5.7.0 by digest (was floating :latest)
+    image: certbot/certbot:v5.7.0@sha256:34ee91d2f43008eb78a007d22f23ed4b2eaa9a454cb27ca2c042b49527a695b4
     restart: always
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
     volumes:

--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 export rsa_key_size=4096
 export data_path="local/certbot"
+# Certbot release whose TLS config we download. Pinned (not "main") so a given
+# repo revision always fetches identical files; keep in sync with the certbot
+# container image tag in docker-compose.yml.
+export certbot_ref="v5.7.0"
 export nginx_server_file="local/nginx/conf.d/00-katalyst.conf"
 export nginx_server_template_http="local/nginx/conf.d/katalyst-http.conf.template"
 export nginx_server_template_https="local/nginx/conf.d/katalyst-https.conf.template"
@@ -12,11 +16,40 @@ export PATH="$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:
 # Functions
 #####
 
+# Download $1 to $2, atomically. Streams to a temp file in the target directory
+# and only moves it into place on success, so neither an HTTP error (--fail nets
+# the error body) nor an interrupted transfer can leave a partial/unparseable
+# file at the final path (which would make nginx fail to start). $3 is a label
+# for error messages.
+downloadTlsFile () {
+  local url="$1" target="$2" name="$3" tmp
+  tmp="$(mktemp "${target}.XXXXXX")" || {
+    echo -n "Failed to create temp file for $name... "
+    printMessage failed
+    exit 1
+  }
+  if curl -fsS "$url" -o "$tmp"; then
+    # mktemp creates the file 0600; these are public TLS config files, so restore
+    # the world-readable perms the previous `curl -o` produced before moving.
+    chmod 0644 "$tmp"
+    mv "$tmp" "$target"
+  else
+    rm -f "$tmp"
+    echo -n "Failed to download $name... "
+    printMessage failed
+    exit 1
+  fi
+}
+
 leCertEmit () {
   echo "## Downloading recommended TLS parameters ..."
   mkdir -p "$data_path/conf"
-  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
-  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  downloadTlsFile \
+    "https://raw.githubusercontent.com/certbot/certbot/${certbot_ref}/certbot/src/certbot/_internal/plugins/nginx/tls_configs/options-ssl-nginx.conf" \
+    "$data_path/conf/options-ssl-nginx.conf" "options-ssl-nginx.conf"
+  downloadTlsFile \
+    "https://raw.githubusercontent.com/certbot/certbot/${certbot_ref}/certbot/src/certbot/ssl-dhparams.pem" \
+    "$data_path/conf/ssl-dhparams.pem" "ssl-dhparams.pem"
   echo
 
   echo " Creating dummy certificate for $nginx_url..."


### PR DESCRIPTION
Port of #256 to the `full-realm` branch.

## Why

`full-realm`'s `init.sh` has the **same certbot bug** that #256 fixed on master: the TLS-config download URLs 404 (certbot restructured its repo), and because `curl -s > file` doesn't fail on HTTP errors, the `404: Not Found` body was written into `options-ssl-nginx.conf`, so nginx crash-loops with `unexpected end of file, expecting ";" or "}"`. Running `./init.sh` on this branch is broken until this lands.

## Changes

### `init.sh` (the actual fix)
- Point both downloads at their current paths, **pinned to the certbot `v5.7.0` release tag** (new `certbot_ref` var, kept in sync with the certbot container image) rather than the mutable `main` branch.
- Download to a temp file and `mv` into place only on success (`curl --fail`), so neither an HTTP error nor an interrupted transfer can leave a partial/unparseable config for nginx.

### `docker-compose.yml` — pin shared images by digest to match master
`full-realm` was previously unpinned (floating/`:latest` tags). Bringing the shared images in line with master:

| Service | Before (full-realm) | After |
|---|---|---|
| nginx | `1.31-alpine` | `1.31.3-alpine` @sha256 |
| certbot | `certbot/certbot` (untagged) | `v5.7.0` @sha256 |
| postgres-exporter | untagged | `v0.20.1` @sha256 |
| node-exporter | `:latest` | `v1.12.1` @sha256 |
| cadvisor | `v0.55.1` (no digest) | `v0.55.1` @sha256 |

Full-realm-only services (`nats`, `nats-exporter`, `archipelago`, `archipelago-core`, `catalyst-stats`, and the DCL `${...}`-tagged images) are intentionally left untouched, and `postgres:16` is unchanged.

## Testing
- `docker compose config` renders the full file cleanly; all five images resolve to the pinned digests.
- `bash -n init.sh` passes; the atomic-download helper was tested for both success and 404 (no partial file, no temp leftover).
- Metric compatibility was already verified against the Foundation's Prometheus rules in #256 (only `pg_up` and cpu/filesystem node metrics are used — all unaffected); the same images apply here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)