### PR TITLE
feat: configure the post /entities rate limit

### DIFF
--- a/.env-advanced.example
+++ b/.env-advanced.example
@@ -6,3 +6,8 @@ REGENERATE=0
 MAINTENANCE_MODE=0
 DOCKER_TAG=latest
 LAMB2_DOCKER_TAG=latest
+
+# NOTE: the POST /content/entities rate limit knobs are documented in .env.example, not here.
+# docker-compose.yml reads them with ${VAR:-default} substitution, and Compose resolves that from the
+# shell environment and .env only — never from this file. A value set here is silently ignored unless
+# init.sh also re-exports it, which is why DOCKER_TAG above needs `export DOCKER_TAG=...` in init.sh.

--- a/.env-advanced.example
+++ b/.env-advanced.example
@@ -7,7 +7,13 @@ MAINTENANCE_MODE=0
 DOCKER_TAG=latest
 LAMB2_DOCKER_TAG=latest
 
-# NOTE: the POST /content/entities rate limit knobs are documented in .env.example, not here.
-# docker-compose.yml reads them with ${VAR:-default} substitution, and Compose resolves that from the
-# shell environment and .env only — never from this file. A value set here is silently ignored unless
-# init.sh also re-exports it, which is why DOCKER_TAG above needs `export DOCKER_TAG=...` in init.sh.
+# NOTE: the POST /content/entities rate limit settings are documented in .env.example, not here.
+#
+# Put POST_ENTITIES_RATE_LIMIT_MAX and POST_ENTITIES_RATE_LIMIT_WINDOW_SECONDS in .env: they are read
+# in docker-compose.yml as ${VAR:-default}, and Compose resolves that from the shell environment and
+# .env only, so a value set in this file is silently ignored. That is also why DOCKER_TAG above only
+# works thanks to an explicit `export DOCKER_TAG=...` in init.sh — worth knowing before adding any new
+# substituted variable here.
+#
+# TRUSTED_CLIENT_IP_HEADER is not substituted, so it would take effect from this file too. Keep it in
+# .env anyway, next to the notes explaining what leaving it unset does to the limit.

--- a/.env.example
+++ b/.env.example
@@ -7,30 +7,43 @@ REALM_NAME=test
 # ---------------------------------------------------------------------------
 # Rate limit on POST /content/entities (scene and item deployments)
 # ---------------------------------------------------------------------------
-# Everything below is optional: docker-compose.yml applies these same defaults, so the limit is
-# already active on a stock node. Uncomment only to change a value.
+# The limit is active on a stock node without any of this: docker-compose.yml already defaults the
+# max and the window. The header below has NO default and is the one worth a decision.
 #
-# These belong in THIS file rather than .env-advanced: Compose resolves ${VAR:-default} from the
-# shell environment and .env only, so a value placed in .env-advanced is silently ignored.
+# Keep these in THIS file rather than .env-advanced. Compose resolves the ${VAR:-default} forms in
+# docker-compose.yml from the shell environment and .env only, so a max or window placed in
+# .env-advanced is silently ignored.
 #
 # The endpoint accepts a multi-MB upload from an unauthenticated client and buffers it before it can
 # be rejected. nginx's own limit_req zones are keyed on $uri, so they cap the endpoint's total rate
-# rather than any single client's share of it — and /content/entities has no limit_req at all. This
-# budget is per client, per window.
-#POST_ENTITIES_RATE_LIMIT_MAX=200
+# rather than any single client's share of it — and /content/entities has no limit_req at all.
+#
+# 6 per minute is well above what deploying a scene needs and far below what abusing the endpoint
+# needs. Raise it if you run a node that hosts bulk publishers.
+#POST_ENTITIES_RATE_LIMIT_MAX=6
 #POST_ENTITIES_RATE_LIMIT_WINDOW_SECONDS=60
 
-# Which request header carries the deploying client's address.
+# Which request header carries the deploying client's address. NO DEFAULT — read this before
+# deciding, because the two states behave very differently:
 #
-# Defaults to x-real-ip, which our nginx sets from $remote_addr on every /content route. It
-# overwrites whatever the client sent, which is what makes it safe to key a limit on: a client can
-# neither escape its own budget nor spend someone else's by forging the header.
+#   unset    the budget is keyed on the connecting peer, which for a stock node is always nginx.
+#            The limit then applies to the WHOLE NODE: 6 deployments per minute shared by every
+#            client, so one busy publisher can shut out everyone else. The server logs a warning at
+#            startup when this is the case.
 #
-# Change it only if you put another proxy or CDN in front of nginx — then $remote_addr is that
-# proxy, and every client behind it shares one budget. Behind Cloudflare:
-#   TRUSTED_CLIENT_IP_HEADER=cf-connecting-ip
-# Naming a header your edge does not overwrite makes the limit trivially bypassable, so leave this
-# alone if you are unsure. To check which path is live, look at the key_source label on
-# rate_limiter_requests_total: "header" means this is working, "socket" means it is being ignored
-# and every client is sharing a single bucket.
+#   set      the budget is keyed per client, which is the intent.
+#
+# For a stock node — nginx in front, nothing else — the correct value is x-real-ip. Our nginx sets
+# it from $remote_addr on every /content route and OVERWRITES whatever the client sent, which is what
+# makes it safe to key a limit on: a client can neither escape its own budget nor spend a victim's by
+# forging the header.
 #TRUSTED_CLIENT_IP_HEADER=x-real-ip
+#
+# If you put another proxy or CDN in front of nginx, $remote_addr is that proxy and x-real-ip would
+# lump every client behind it into one budget. Behind Cloudflare, use its header instead:
+#TRUSTED_CLIENT_IP_HEADER=cf-connecting-ip
+#
+# Naming a header your own edge does not overwrite makes the limit trivially bypassable — a client
+# just sends the header itself — so only name one you are certain your proxy sets. To check which
+# path is live, look at the key_source label on rate_limiter_requests_total: "header" means this is
+# working, "socket" means it is being ignored and every client is sharing a single bucket.

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,34 @@ EMAIL=a@a.com
 CONTENT_SERVER_STORAGE=./storage
 CATALYST_URL=http://localhost
 REALM_NAME=test
+
+# ---------------------------------------------------------------------------
+# Rate limit on POST /content/entities (scene and item deployments)
+# ---------------------------------------------------------------------------
+# Everything below is optional: docker-compose.yml applies these same defaults, so the limit is
+# already active on a stock node. Uncomment only to change a value.
+#
+# These belong in THIS file rather than .env-advanced: Compose resolves ${VAR:-default} from the
+# shell environment and .env only, so a value placed in .env-advanced is silently ignored.
+#
+# The endpoint accepts a multi-MB upload from an unauthenticated client and buffers it before it can
+# be rejected. nginx's own limit_req zones are keyed on $uri, so they cap the endpoint's total rate
+# rather than any single client's share of it — and /content/entities has no limit_req at all. This
+# budget is per client, per window.
+#POST_ENTITIES_RATE_LIMIT_MAX=200
+#POST_ENTITIES_RATE_LIMIT_WINDOW_SECONDS=60
+
+# Which request header carries the deploying client's address.
+#
+# Defaults to x-real-ip, which our nginx sets from $remote_addr on every /content route. It
+# overwrites whatever the client sent, which is what makes it safe to key a limit on: a client can
+# neither escape its own budget nor spend someone else's by forging the header.
+#
+# Change it only if you put another proxy or CDN in front of nginx — then $remote_addr is that
+# proxy, and every client behind it shares one budget. Behind Cloudflare:
+#   TRUSTED_CLIENT_IP_HEADER=cf-connecting-ip
+# Naming a header your edge does not overwrite makes the limit trivially bypassable, so leave this
+# alone if you are unsure. To check which path is live, look at the key_source label on
+# rate_limiter_requests_total: "header" means this is working, "socket" means it is being ignored
+# and every client is sharing a single bucket.
+#TRUSTED_CLIENT_IP_HEADER=x-real-ip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,13 +86,13 @@ services:
       - BOOTSTRAP_FROM_SCRATCH=${BOOTSTRAP_FROM_SCRATCH:-false}
       - POSTGRES_HOST=${POSTGRES_HOST:-postgres}
       - POSTGRES_PORT=${POSTGRES_PORT:-5432}
-      # Per-client rate limit on POST /entities. Defaulted here rather than left to .env-advanced
-      # because the header is a property of this topology, not an operator preference: the container
-      # only `expose`s 6969, so nginx is its sole ingress, and content_proxy.conf sets X-Real-IP with
-      # `$remote_addr` — overwriting anything the client sent, which is what makes it safe to key on.
-      # Without it the socket peer is nginx for every request and all clients would share one budget.
-      - TRUSTED_CLIENT_IP_HEADER=${TRUSTED_CLIENT_IP_HEADER:-x-real-ip}
-      - POST_ENTITIES_RATE_LIMIT_MAX=${POST_ENTITIES_RATE_LIMIT_MAX:-200}
+      # Rate limit on POST /entities. `TRUSTED_CLIENT_IP_HEADER` is deliberately not defaulted here:
+      # it names a header this deployment promises will arrive, and that promise depends on a proxy
+      # chain only the operator can vouch for. It reaches the container through `env_file` below, so
+      # uncommenting it in .env is enough — see the notes there, which explain that leaving it unset
+      # makes this budget node-wide rather than per client, because nginx is then the only peer the
+      # server ever sees.
+      - POST_ENTITIES_RATE_LIMIT_MAX=${POST_ENTITIES_RATE_LIMIT_MAX:-6}
       - POST_ENTITIES_RATE_LIMIT_WINDOW_SECONDS=${POST_ENTITIES_RATE_LIMIT_WINDOW_SECONDS:-60}
     env_file:
       - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,14 @@ services:
       - BOOTSTRAP_FROM_SCRATCH=${BOOTSTRAP_FROM_SCRATCH:-false}
       - POSTGRES_HOST=${POSTGRES_HOST:-postgres}
       - POSTGRES_PORT=${POSTGRES_PORT:-5432}
+      # Per-client rate limit on POST /entities. Defaulted here rather than left to .env-advanced
+      # because the header is a property of this topology, not an operator preference: the container
+      # only `expose`s 6969, so nginx is its sole ingress, and content_proxy.conf sets X-Real-IP with
+      # `$remote_addr` — overwriting anything the client sent, which is what makes it safe to key on.
+      # Without it the socket peer is nginx for every request and all clients would share one budget.
+      - TRUSTED_CLIENT_IP_HEADER=${TRUSTED_CLIENT_IP_HEADER:-x-real-ip}
+      - POST_ENTITIES_RATE_LIMIT_MAX=${POST_ENTITIES_RATE_LIMIT_MAX:-200}
+      - POST_ENTITIES_RATE_LIMIT_WINDOW_SECONDS=${POST_ENTITIES_RATE_LIMIT_WINDOW_SECONDS:-60}
     env_file:
       - .env
       - .env-advanced


### PR DESCRIPTION
## Why

The content server now applies a rate limit to `POST /content/entities` (decentraland/catalyst#1964). This wires it up for a compose-based node.

`/content/entities` currently has **no** `limit_req` at the proxy, and the zones that do exist are keyed on `$uri`, so they cap an endpoint's total rate rather than any single client's share of it. The endpoint accepts a multi-MB upload from an unauthenticated client and buffers it before anything can reject it.

## What

`docker-compose.yml`, on `content-server`:

```yaml
- POST_ENTITIES_RATE_LIMIT_MAX=${POST_ENTITIES_RATE_LIMIT_MAX:-6}
- POST_ENTITIES_RATE_LIMIT_WINDOW_SECONDS=${POST_ENTITIES_RATE_LIMIT_WINDOW_SECONDS:-60}
```

**6 per minute**, active on a stock node with no configuration — well above what deploying a scene needs, far below what abusing the endpoint needs.

## `TRUSTED_CLIENT_IP_HEADER` has no default, on purpose

It names a header this deployment *promises* will arrive, and that promise rests on a proxy chain only the operator can vouch for. Naming a header the edge does not overwrite makes the limit bypassable by simply sending it, so this is not a safe thing to guess on an operator's behalf.

It is not read through `${VAR:-default}`, so it reaches the container via `env_file` — uncommenting it in `.env` is enough.

The consequence of leaving it unset is documented at the point of decision rather than implied:

| | Keyed on | Effect |
| --- | --- | --- |
| **unset** | the connecting peer — always nginx on a stock node | budget is **node-wide**: 6 deployments/min shared by every client, so one busy publisher can shut out the rest |
| **set** | the client address | per-client budget, which is the intent |

For a stock node the correct value is `x-real-ip`: our nginx sets it from `$remote_addr` on every `/content` route and **overwrites** whatever the client sent, so a client can neither escape its own budget nor spend a victim's. Behind a CDN, name that edge's header instead (`cf-connecting-ip` for Cloudflare).

The server logs a warning at startup while it is unset, and the `key_source` label on `rate_limiter_requests_total` distinguishes the two states after the fact — `header` means it is working, `socket` means every client is sharing one bucket.

## Why the max and window are in `.env.example`, not `.env-advanced.example`

Compose resolves `${VAR:-default}` from the shell environment and `.env` **only**. A value in `.env-advanced` is silently ignored — verified:

```
# POST_ENTITIES_RATE_LIMIT_MAX=99 in .env-advanced
POST_ENTITIES_RATE_LIMIT_MAX: "6"       # <- ignored
```

`DOCKER_TAG` and `LAMB2_DOCKER_TAG` work only because `init.sh` re-exports them after sourcing (`init.sh:256-257`). Rather than extend that workaround, these live in the file Compose already reads, and `.env-advanced.example` carries a note. **Pre-existing trap worth knowing separately:** any new variable added to `.env-advanced.example` and consumed via `${VAR:-default}` needs a matching `export` in `init.sh` or it will not take effect.

## Verification

`docker compose config` — the real resolution path, not a hand-parse:

| Scenario | Result |
| --- | --- |
| Stock node, nothing uncommented | max `6`, window `60`, **no** `TRUSTED_CLIENT_IP_HEADER` entry ✅ |
| Header uncommented in `.env` | `x-real-ip` ✅ |
| Max overridden in `.env` | `25` ✅ |
| Max set in `.env-advanced` | ignored, stays `6` — the trap above ✅ |

No throwaway env files are committed; `.env`, `.env-advanced` and `.env-database-*` are gitignored.

Pairs with decentraland/catalyst#1964, which must be released first — that PR is itself blocked on `@dcl/rate-limiter-component` reaching npm.
