### PR TITLE
feat: configure the post /entities rate limit (full-realm)

### DIFF
--- a/.env-advanced.example
+++ b/.env-advanced.example
@@ -6,3 +6,14 @@ REGENERATE=0
 MAINTENANCE_MODE=0
 DOCKER_TAG=latest
 LAMB2_DOCKER_TAG=latest
+
+# NOTE: the POST /content/entities rate limit settings are documented in .env.example, not here.
+#
+# Put POST_ENTITIES_RATE_LIMIT_MAX and POST_ENTITIES_RATE_LIMIT_WINDOW_SECONDS in .env: they are read
+# in docker-compose.yml as ${VAR:-default}, and Compose resolves that from the shell environment and
+# .env only, so a value set in this file is silently ignored. That is also why DOCKER_TAG above only
+# works thanks to an explicit `export DOCKER_TAG=...` in init.sh — worth knowing before adding any new
+# substituted variable here.
+#
+# TRUSTED_CLIENT_IP_HEADER is not substituted, so it would take effect from this file too. Keep it in
+# .env anyway, next to the notes explaining what leaving it unset does to the limit.

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,47 @@ EMAIL=a@a.com
 CONTENT_SERVER_STORAGE=./storage
 CATALYST_URL=http://localhost
 REALM_NAME=test
+
+# ---------------------------------------------------------------------------
+# Rate limit on POST /content/entities (scene and item deployments)
+# ---------------------------------------------------------------------------
+# The limit is active on a stock node without any of this: docker-compose.yml already defaults the
+# max and the window. The header below has NO default and is the one worth a decision.
+#
+# Keep these in THIS file rather than .env-advanced. Compose resolves the ${VAR:-default} forms in
+# docker-compose.yml from the shell environment and .env only, so a max or window placed in
+# .env-advanced is silently ignored.
+#
+# The endpoint accepts a multi-MB upload from an unauthenticated client and buffers it before it can
+# be rejected. nginx's own limit_req zones are keyed on $uri, so they cap the endpoint's total rate
+# rather than any single client's share of it — and /content/entities has no limit_req at all.
+#
+# 6 per minute is well above what deploying a scene needs and far below what abusing the endpoint
+# needs. Raise it if you run a node that hosts bulk publishers.
+#POST_ENTITIES_RATE_LIMIT_MAX=6
+#POST_ENTITIES_RATE_LIMIT_WINDOW_SECONDS=60
+
+# Which request header carries the deploying client's address. NO DEFAULT — read this before
+# deciding, because the two states behave very differently:
+#
+#   unset    the budget is keyed on the connecting peer, which for a stock node is always nginx.
+#            The limit then applies to the WHOLE NODE: 6 deployments per minute shared by every
+#            client, so one busy publisher can shut out everyone else. The server logs a warning at
+#            startup when this is the case.
+#
+#   set      the budget is keyed per client, which is the intent.
+#
+# For a stock node — nginx in front, nothing else — the correct value is x-real-ip. Our nginx sets
+# it from $remote_addr on every /content route and OVERWRITES whatever the client sent, which is what
+# makes it safe to key a limit on: a client can neither escape its own budget nor spend a victim's by
+# forging the header.
+#TRUSTED_CLIENT_IP_HEADER=x-real-ip
+#
+# If you put another proxy or CDN in front of nginx, $remote_addr is that proxy and x-real-ip would
+# lump every client behind it into one budget. Behind Cloudflare, use its header instead:
+#TRUSTED_CLIENT_IP_HEADER=cf-connecting-ip
+#
+# Naming a header your own edge does not overwrite makes the limit trivially bypassable — a client
+# just sends the header itself — so only name one you are certain your proxy sets. To check which
+# path is live, look at the key_source label on rate_limiter_requests_total: "header" means this is
+# working, "socket" means it is being ignored and every client is sharing a single bucket.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,6 +160,14 @@ services:
       - BOOTSTRAP_FROM_SCRATCH=${BOOTSTRAP_FROM_SCRATCH:-false}
       - POSTGRES_HOST=${POSTGRES_HOST:-postgres}
       - POSTGRES_PORT=${POSTGRES_PORT:-5432}
+      # Rate limit on POST /entities. `TRUSTED_CLIENT_IP_HEADER` is deliberately not defaulted here:
+      # it names a header this deployment promises will arrive, and that promise depends on a proxy
+      # chain only the operator can vouch for. It reaches the container through `env_file` below, so
+      # uncommenting it in .env is enough — see the notes there, which explain that leaving it unset
+      # makes this budget node-wide rather than per client, because nginx is then the only peer the
+      # server ever sees.
+      - POST_ENTITIES_RATE_LIMIT_MAX=${POST_ENTITIES_RATE_LIMIT_MAX:-6}
+      - POST_ENTITIES_RATE_LIMIT_WINDOW_SECONDS=${POST_ENTITIES_RATE_LIMIT_WINDOW_SECONDS:-60}
     env_file:
       - .env
       - .env-advanced


### PR DESCRIPTION
Ports decentraland/catalyst-owner#258 to `full-realm`, following the convention #257 used.

Clean cherry-pick of `c3af666` — no conflicts, same 3 files, same 63 lines.

## What it does

The content server applies a rate limit to `POST /content/entities` (decentraland/catalyst#1964). This configures it for a compose node: **6 requests per 60 seconds**, active with no configuration.

`TRUSTED_CLIENT_IP_HEADER` has **no default** on purpose — it names a header the deployment promises will arrive, and that promise rests on a proxy chain only the operator can vouch for. Left unset the peer is always nginx, so the budget becomes node-wide rather than per client; the server warns at startup while that is the case. For a stock node the correct value is `x-real-ip`, documented (commented out) in `.env.example`.

Full reasoning is in #258.

## Verified on this branch, not assumed

`full-realm` carries a different topology — it adds `nats`, `nats-exporter`, `stats`, `archipelago` and `archipelago-core`, and its `docker-compose.yml` is 84 lines longer than master's. The three claims the config depends on all still hold here:

| Claim | On `full-realm` |
| --- | --- |
| `content-server` is nginx-only (`expose`, no published `ports`) | ✅ holds |
| `content_proxy.conf` sets `X-Real-IP` from `$remote_addr` | ✅ holds (line 11) |
| `.env.example` / `.env-advanced.example` match master | ✅ identical, cherry-pick applied cleanly |

The extra services are comms-related and sit outside the content path.

`docker compose config` on this branch:

| Scenario | Result |
| --- | --- |
| Stock node, nothing uncommented | max `6`, window `60`, **no** `TRUSTED_CLIENT_IP_HEADER` entry |
| Header uncommented in `.env` | `x-real-ip` |

Same behaviour as master. No throwaway env files committed.