### PR TITLE
fix: avoid reinitializing on every cron run

### DIFF
--- a/crontab.sh
+++ b/crontab.sh
@@ -12,14 +12,28 @@ git config rebase.autoStash true
 # select the provided GIT_CATALYST_OWNER_BRANCH or fallback to current_branch
 branch=${GIT_CATALYST_OWNER_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
 
-# Update the catalyst-owner version using the current branch
-git pull origin "$branch" | grep -o 'Already up to date.'
-isUpToDate=$?
+# Update the catalyst-owner version using the current branch.
+# Do not continue with either action if the pull itself fails: a failed pull
+# must not be interpreted as a repository update.
+previousCommit=$(git rev-parse HEAD) || {
+  echo 'Unable to determine the current catalyst-owner revision; skipping cron actions'
+  exit 1
+}
 
-if [ $isUpToDate -ne 0 ]; then
-  # if it is not up to date, reinit the catalyst to apply changes
+if ! git pull origin "$branch"; then
+  echo "Failed to update catalyst-owner from origin/$branch; skipping reinitialization and SQS processing"
+  exit 1
+fi
+
+currentCommit=$(git rev-parse HEAD) || {
+  echo 'Unable to determine the updated catalyst-owner revision; skipping cron actions'
+  exit 1
+}
+
+if [ "$previousCommit" != "$currentCommit" ]; then
+  # Reinitialize the catalyst only when the checkout changed.
   bash ./init.sh
 else
-  # update the version if we have messages in the SQS
+  # Process pending deployments when the checkout is already up to date.
   bash ./receive-sqs.sh
 fi

--- a/crontab.sh
+++ b/crontab.sh
@@ -16,7 +16,7 @@ branch=${GIT_CATALYST_OWNER_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
 git pull origin "$branch" | grep -o 'Already up to date.'
 isUpToDate=$?
 
-if [ $isUpToDate -eq 0 ]; then
+if [ $isUpToDate -ne 0 ]; then
   # if it is not up to date, reinit the catalyst to apply changes
   bash ./init.sh
 else


### PR DESCRIPTION
The cron freshness check currently treats `Already up to date.` as the condition to run `init.sh`, so every scheduled run recreates the stack even when there are no changes.

Invert the condition so `init.sh` runs only after a successful update, while the up-to-date path processes SQS messages.

Validation: `bash -n crontab.sh` and `git diff --check`.